### PR TITLE
Allowing alternate implementations of flatMap.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,11 @@ if (!Array.prototype.flat) {
 				return result.concat(stack);
 			},
 			writable: true
-		},
+		}
+  });
+}
+if (!Array.prototype.flatMap) {
+  Object.defineProperties(Array.prototype, {
 		flatMap: {
 			configurable: true,
 			value: function flatMap(callback) {


### PR DESCRIPTION
I don't know why, but your .flat was working for me and your .flatMap was not. And the core-js .flatMap worked for me, but I couldn't get a working .flat. So, this prevents array-flat-polyfill from overwriting other implementations of .flatMap so that I can use both. :)