### PR TITLE
Fix polyfill and added unit tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 'current',
+        },
+      },
+    ],
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "build": "rollup --config --silent",
     "prepublish": "npm run build",
-    "test": "eslint src/*.js --cache --ignore-path .gitignore --quiet"
+    "lint": "eslint src/*.js --cache --ignore-path .gitignore --quiet",
+    "test": "jest && npm run lint"
   },
   "engines": {
     "node": ">=6.0.0"
@@ -25,8 +26,10 @@
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.1.6",
     "babel-eslint": "^10.0.1",
+    "babel-jest": "^24.7.0",
     "eslint": "^5.6.0",
     "eslint-config-dev": "^2.0.0",
+    "jest": "^24.7.0",
     "rollup": "^0.67.3",
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-terser": "^3.0.0"
@@ -35,7 +38,9 @@
     "extends": "dev",
     "parser": "babel-eslint",
     "rules": {
-      "no-unused-vars": [0]
+      "no-unused-vars": [
+        0
+      ]
     }
   },
   "keywords": [
@@ -45,5 +50,6 @@
     "flatMap",
     "concat",
     "flatten"
-  ]
+  ],
+  "dependencies": {}
 }

--- a/src/flat.js
+++ b/src/flat.js
@@ -1,0 +1,8 @@
+export function flat(depth = 1) {
+	return this.reduce(
+		(acc, val) => Array.isArray(val)
+			? acc.concat(val.flat(depth - 1))
+			: acc.concat(val),
+		[]
+	);
+}

--- a/src/flat.js
+++ b/src/flat.js
@@ -1,8 +1,13 @@
 export function flat(depth = 1) {
 	return this.reduce(
-		(acc, val) => Array.isArray(val)
-			? acc.concat(val.flat(depth - 1))
-			: acc.concat(val),
+		(acc, val) => {
+			if (depth >= 1 && Array.isArray(val)) {
+				acc.push(...flat.call(val, depth - 1))
+			} else {
+				acc.push(val);
+			}
+			return acc;
+		},
 		[]
 	);
 }

--- a/src/flat.js
+++ b/src/flat.js
@@ -1,5 +1,5 @@
 export function flat(depth = 1) {
-	return this.reduce(
+	return Array.prototype.reduce.call(this,
 		(acc, val) => {
 			if (depth >= 1 && Array.isArray(val)) {
 				acc.push(...flat.call(val, depth - 1))

--- a/src/flatMap.js
+++ b/src/flatMap.js
@@ -1,3 +1,5 @@
+import { flat } from "./flat";
+
 export function flatMap(callback) {
-	return Array.prototype.map.apply(this, arguments).flat();
+	return flat.call(Array.prototype.map.apply(this, arguments));
 }

--- a/src/flatMap.js
+++ b/src/flatMap.js
@@ -1,0 +1,3 @@
+export function flatMap(callback, thisArg) {
+	return this.map(callback, thisArg).flat();
+}

--- a/src/flatMap.js
+++ b/src/flatMap.js
@@ -1,3 +1,3 @@
-export function flatMap(callback, thisArg) {
+export function flatMap(callback) {
 	return Array.prototype.map.apply(this, arguments).flat();
 }

--- a/src/flatMap.js
+++ b/src/flatMap.js
@@ -1,3 +1,3 @@
 export function flatMap(callback, thisArg) {
-	return this.map(callback, thisArg).flat();
+	return Array.prototype.map.apply(this, arguments).flat();
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,33 +1,16 @@
+import { flat } from "./flat";
+import { flatMap } from "./flatMap";
+
 if (!Array.prototype.flat) {
 	Object.defineProperties(Array.prototype, {
 		flat: {
 			configurable: true,
-			value: function flat() {
-				let depth = isNaN(arguments[0]) ? 1 : Number(arguments[0]);
-				const stack = Array.prototype.slice.call(this);
-				const result = [];
-
-				while (depth && stack.length) {
-					const next = stack.pop();
-
-					if (Object(next) instanceof Array) {
-						--depth;
-
-						Array.prototype.push.apply(stack, next);
-					} else {
-						result.unshift(next);
-					}
-				}
-
-				return result.concat(stack);
-			},
+			value: flat,
 			writable: true
 		},
 		flatMap: {
 			configurable: true,
-			value: function flatMap(callback) {
-				return Array.prototype.map.apply(this, arguments).flat();
-			},
+			value: flatMap,
 			writable: true
 		}
 	});

--- a/test/flat.test.js
+++ b/test/flat.test.js
@@ -1,0 +1,11 @@
+import { flat } from "../src/flat";
+
+test("flat() examples", () => {
+	expect(flat.call([1, 2, [3, 4]])).toEqual([1, 2, 3, 4]);
+	expect(flat.call([1, 2, [3, 4, [5, 6]]])).toEqual([1, 2, 3, 4, [5, 6]]);
+	expect(flat.call([1, 2, [3, 4, [5, 6]]], 2)).toEqual([1, 2, 3, 4, 5, 6]);
+	expect(flat.call([1, 2 , 3, [1, 2, 3, 4, [2, 3, 4]]], 2)).toEqual([1, 2, 3, 1, 2, 3, 4, 2, 3, 4]);
+	expect(flat.call([[1], [2], [3], [4]])).toEqual([1, 2, 3, 4]);
+	expect(flat.call([[[1]], [2], [3], [4]])).toEqual([[1], 2, 3, 4]);
+	expect(flat.call([[[1]], [2], [3], [4]], 2)).toEqual([1, 2, 3, 4]);
+})

--- a/test/flatMap.test.js
+++ b/test/flatMap.test.js
@@ -1,0 +1,5 @@
+import { flatMap } from "../src/flatMap";
+
+test("flatMap() examples", () => {
+	expect(flatMap.call([1, 2, 3, 4], x => [x * 2])).toEqual([2, 4, 6, 8]);
+});

--- a/test/flatMap.test.js
+++ b/test/flatMap.test.js
@@ -3,3 +3,21 @@ import { flatMap } from "../src/flatMap";
 test("flatMap() examples", () => {
 	expect(flatMap.call([1, 2, 3, 4], x => [x * 2])).toEqual([2, 4, 6, 8]);
 });
+
+test("only one level is flattened", () => {
+	expect(flatMap.call([1, 2, 3, 4], x => [[x * 2]])).toEqual([[2], [4], [6], [8]]);
+});
+
+test("generate a list of words from a list of sentences", () => {
+	expect(flatMap.call(["it's Sunny in", "", "California"], x => x.split(" "))).toEqual(["it's","Sunny","in", "", "California"]);
+});
+
+test("remove all the negative numbers and split the odd numbers into an even number and a 1", () => {
+	const arr = [5, 4, -3, 20, 17, -33, -4, 18];
+	const map = n => n < 0
+		? []
+		: n % 2 == 0
+			? [n]
+			: [n - 1, 1];
+	expect(flatMap.call(arr, map)).toEqual([4, 1, 4, 20, 16, 1, 18]);
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,4 +5,5 @@ test("polyfill", () => {
 	expect([].flatMap).toBeUndefined();
 	require("../src/index");
 	expect([].flat).toBeDefined();
+	expect([].flatMap).toBeDefined();
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,8 @@
+test("polyfill", () => {
+	delete Array.prototype.flat;
+	delete Array.prototype.flatMap;
+	expect([].flat).toBeUndefined();
+	expect([].flatMap).toBeUndefined();
+	require("../src/index");
+	expect([].flat).toBeDefined();
+});


### PR DESCRIPTION
- **Fixes** problems with the polyfill, for example `[[1], [2], [3]].flat()` became `[[1], [2], 3]` previously. Now the implementation is based on the [MDN alternative](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat#Alternative).
- **Added** Jest unit tests.